### PR TITLE
Fix markdown headers

### DIFF
--- a/COMUNICACAO.md
+++ b/COMUNICACAO.md
@@ -4,45 +4,45 @@
 
 <br>
 
-###[Voltar para índice](README.md)
+### [Voltar para índice](README.md)
 
 ## GERAL
 
-####Utilizar comunicação assíncrona sempre que possível
+#### Utilizar comunicação assíncrona sempre que possível
 Quando você precisar de algo do colega e for mandar uma mensagem pra ele, envie logo sua dúvida inteira em vez de perguntar "oi, vc ta ai?". Sempre assuma que a pessoa não está disponível e deixe ja sua pergunta clara e objetiva, assim a pessoa consegue responder o quanto antes e otimiza para os dois lados.
 
-####Issue no GitHub > email > Slack
+#### Issue no GitHub > email > Slack
 Quando precisar repassar um problema pros devs (ou outras áreas) prefira sempre o meio de comunicação que guarda melhor o histórico do problema. Evite ao máximo utilizar o slack para trocar informações que preciam ter um log. Caso seja um problema específico de algum produto que temos repositório no GitHub, não tenha medo de diretamente abrir uma issue no repositório para discutirmos o problema la.
 
-####Pergunte muito, mas nos canais certos
+#### Pergunte muito, mas nos canais certos
 Aqui na pagarme ninguém nunca irá lhe podar na busca do conhecimento. Pergunte muito, mas sempre pergunte nos locais onde tenha o maior número de pessoas que saibam assertivamente te dar uma resposta, e tente sempre perguntar em locais que documentam as resposta (novamente, GitHub ou email).
 
-####Ao mencionar alguma coisa, coloque sempre o link
+#### Ao mencionar alguma coisa, coloque sempre o link
 Sempre que você se referir a alguma coisa que tenha o link, cole o link junto com sua mensagem. Nunca assuma que a outra pessoa sabe de qual problema/commit/página/cliente você esta se referindo.
 
-####Todas as informações devem ser abertas a serem compartilhadas por padrão
+#### Todas as informações devem ser abertas a serem compartilhadas por padrão
 Evite sempre criar arquivos em locais onde outas pessoas da empresa não conseguem acessar. Transparência está no coração da nossa cultura, facilitar o tráfego de informações ajuda muito a sermos transparentes.
 
-####Agradecer as pessoas que te ajudaram é sempre legal!
+#### Agradecer as pessoas que te ajudaram é sempre legal!
 Não tenha medo de usar os canais dos slack para agradecer quem te ajudou! Somos seres humanos, gostamos de trocar emoções.
 
 ## EMAIL
 
-####Ao enviar emails, separe um assunto por email
+#### Ao enviar emails, separe um assunto por email
 É mais fácil para quem recebeu os emails lidar com eles de 1 por 1. Colocar mais de um assunto no email pode causar demoras para a pessoa responder pois ela vai tentar resolver tudo antes de te responder.
 
-####Sempre responda os emails mesmo que nada precise ser feito
+#### Sempre responda os emails mesmo que nada precise ser feito
 É sempre bom comunicar pra quem enviou o email que o destinatário recebeu a mensagem.
 
-####Em caso de email urgente, marque a pessoa no slack
+#### Em caso de email urgente, marque a pessoa no slack
 Não tem problema em pingar a pessoa no slack falando que você enviou um email importante pra ela que precisa ser respondido o quanto antes. Lembre-se sempre que o slack não deve ser o canal que a mensagem está, mas é o canal que estamos todos conectados e esse é um bom uso pra ele.
 
 ## CALLS
 
-####Use calls (skype, hangouts, appearin) pra resolver problemas que vão e voltam por email
+#### Use calls (skype, hangouts, appearin) pra resolver problemas que vão e voltam por email
 Caso um problema esteja precisando de comunicação síncrona pra ser resolvido, não hesite em pedir isso.
 
-####Ao receber um convite para uma call, crie a sala e chame a pessoa ou responda "sim" e espere ela fazer isso
+#### Ao receber um convite para uma call, crie a sala e chame a pessoa ou responda "sim" e espere ela fazer isso
 Parece bobo, mas se você responder "sim" e for criar a sala, provavelmente as 2 pessoas vão tentar criar uma sala. Ao receber um convite de call, apenas crie a sala e responda ja com o link dela para a pessoa que te convidou, ou responda "sim" e aguarde ela te convidar.
 
 ## RESERVA DE SALAS

--- a/CULTURA.md
+++ b/CULTURA.md
@@ -4,7 +4,7 @@
 
 <br>
 
-###[Voltar para índice](README.md)
+### [Voltar para índice](README.md)
 
 ## Motivo
 


### PR DESCRIPTION
I believe Github changed their parsing methods, so having a header prefix and a word without a space in between does not work anymore.